### PR TITLE
Fix actions issues

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,52 @@
+name: Release on tag
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # tags tipo v1.2.3
+  workflow_dispatch: {} # opcional: lanzarlo a mano
+
+permissions:
+  contents: write # necesario para crear la release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history with tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set VERSION from tag
+        id: vars
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      # Genera notas de release desde commits usando git-cliff (conv. commits)
+      - name: Generate release notes (git-cliff)
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: ./cliff.toml
+          # Genera únicamente la última sección (para el tag actual)
+          args: --tag "${{ steps.vars.outputs.version }}" --latest --strip header
+        env:
+          OUTPUT: CHANGELOG-RELEASE.md
+
+      - name: Show generated notes (debug)
+        run: |
+          echo "----- BEGIN NOTES -----"
+          cat CHANGELOG-RELEASE.md
+          echo "----- END NOTES -----"
+
+      # Crea la release usando el body generado
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.vars.outputs.version }}
+          name: brave-sync ${{ steps.vars.outputs.version }}
+          body_path: CHANGELOG-RELEASE.md
+          draft: false
+          prerelease: ${{ contains(steps.vars.outputs.version, '-') }} # v1.2.3-rc.1 => prerelease
+

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -3,11 +3,11 @@ name: Release on tag
 on:
   push:
     tags:
-      - "v*.*.*" # tags tipo v1.2.3
-  workflow_dispatch: {} # opcional: lanzarlo a mano
+      - "v*.*.*"
+  workflow_dispatch: {}
 
 permissions:
-  contents: write # necesario para crear la release
+  contents: write
 
 jobs:
   release:
@@ -24,12 +24,10 @@ jobs:
           VERSION="${GITHUB_REF_NAME}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      # Genera notas de release desde commits usando git-cliff (conv. commits)
       - name: Generate release notes (git-cliff)
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: ./cliff.toml
-          # Genera únicamente la última sección (para el tag actual)
           args: --tag "${{ steps.vars.outputs.version }}" --latest --strip header
         env:
           OUTPUT: CHANGELOG-RELEASE.md
@@ -40,7 +38,6 @@ jobs:
           cat CHANGELOG-RELEASE.md
           echo "----- END NOTES -----"
 
-      # Crea la release usando el body generado
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,53 @@
+# cliff.toml — configuration for git-cliff
+[git]
+# consider all commits; filtering happens via commit_parser below
+conventional_commits = true
+filter_unconventional = false
+tag_pattern = "v[0-9]*"
+
+commit_parsers = [
+  { message = "^feat", group = "✨ Features" },
+  { message = "^fix", group = "🐛 Fixes" },
+  { message = "^perf", group = "⚡ Performance" },
+  { message = "^refactor", group = "♻️ Refactors" },
+  { message = "^docs", group = "📝 Docs" },
+  { message = "^test", group = "✅ Tests" },
+  { message = "^build|^ci", group = "🛠 Build & CI" },
+  { message = "^chore", group = "🧹 Chore" },
+  # breaking changes note
+  { body = "BREAKING CHANGE", group = "💥 Breaking Changes" },
+]
+
+# remove noise like merges/reverts, but keep revert if it has conventional header
+exclude_commits = ["^Merge.*"]
+
+[remote]
+# used for links to commits & issues
+github = true
+# repo is auto-detected from git, override if needed:
+# owner = "ajmasia"
+# repo  = "brave-sync"
+
+[changelog]
+# header is stripped via --strip header in the action
+footer = """
+
+"""
+trim = true
+
+# Template for each release section
+# Available vars: version, previous, date, commits (array), repository, ...
+body = """
+## {{ version }} ({{ date | date(format="%Y-%m-%d") }})
+
+{% if commits | length == 0 %}
+No changes.
+{% else %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first }} ({{ commit.hash | truncate(length=7, end="" ) }}){% if commit.breaking %} **BREAKING**{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brave-sync"
-version = "1.2.0"
+version = "1.2.1"
 description = "Local backup/restore helper for Brave Browser data"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
This pull request introduces automated release management for the project by adding a GitHub Actions workflow to generate release notes and create releases when a new version tag is pushed. It also adds configuration for generating changelogs using git-cliff and bumps the project version to 1.2.1.

Release automation:

* Added `.github/workflows/release-on-tag.yml` to automate release creation on tag push, including generating release notes with git-cliff and publishing a GitHub Release with the generated changelog.

Changelog generation:

* Added `cliff.toml` configuration file for git-cliff, defining commit parsing rules, grouping, and changelog formatting for automated release notes.

Version management:

* Bumped the project version in `pyproject.toml` from 1.2.0 to 1.2.1.